### PR TITLE
Add simple 3D rack builder demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# bug-free-barnacle
+# 3D Rack Builder
+
+This repository contains a simple Three.js based demo that lets you design a server rack layout in the browser.
+
+Open `index.html` in a modern browser. Use the form in the top left corner to choose an equipment type, label, starting rack unit and height in U. Click **Add Equipment** to place the item in the virtual rack. 
+
+Equipment types are rendered with different colors:
+
+- Servers: gray
+- Routers: blue
+- Patch panels: green
+- Blanking plates: black
+
+The example uses assets delivered from the [unpkg](https://unpkg.com) CDN, so internet access is required.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>3D Rack Builder</title>
+    <style>
+        body { margin:0; overflow:hidden; font-family: sans-serif; }
+        #overlay {
+            position:absolute;top:10px;left:10px;z-index:100;background:rgba(255,255,255,0.8);padding:10px;border-radius:4px;
+        }
+        label,input,select {display:block;margin-bottom:5px;}
+    </style>
+</head>
+<body>
+<div id="overlay">
+    <label>Type:
+        <select id="type">
+            <option value="server">Server</option>
+            <option value="router">Router</option>
+            <option value="patch">Patch Panel</option>
+            <option value="blank">Blanking Plate</option>
+        </select>
+    </label>
+    <label>Label: <input id="label" type="text"/></label>
+    <label>Start U (1-42): <input id="start" type="number" min="1" max="42" value="1"/></label>
+    <label>Height (U): <input id="height" type="number" min="1" max="42" value="1"/></label>
+    <button id="add">Add Equipment</button>
+</div>
+<script type="module">
+import * as THREE from 'https://unpkg.com/three@0.152.2/build/three.module.js';
+import { OrbitControls } from 'https://unpkg.com/three@0.152.2/examples/jsm/controls/OrbitControls.js';
+import { CSS2DRenderer, CSS2DObject } from 'https://unpkg.com/three@0.152.2/examples/jsm/renderers/CSS2DRenderer.js';
+
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0xeeeeee);
+const camera = new THREE.PerspectiveCamera(45, window.innerWidth/window.innerHeight, 0.1, 1000);
+const renderer = new THREE.WebGLRenderer({antialias:true});
+renderer.setSize(window.innerWidth, window.innerHeight);
+document.body.appendChild(renderer.domElement);
+
+const labelRenderer = new CSS2DRenderer();
+labelRenderer.setSize(window.innerWidth, window.innerHeight);
+labelRenderer.domElement.style.position = 'absolute';
+labelRenderer.domElement.style.top = '0px';
+document.body.appendChild(labelRenderer.domElement);
+
+const controls = new OrbitControls(camera, labelRenderer.domElement);
+controls.target.set(0,21,0);
+camera.position.set(2,20,40);
+controls.update();
+
+// Rack dimensions
+const rackWidth=6, rackDepth=8, rackHeight=42;
+const postGeom = new THREE.BoxGeometry(0.2, rackHeight+1, 0.2);
+const postMat = new THREE.MeshBasicMaterial({color:0x333333});
+const posts=[
+    new THREE.Mesh(postGeom, postMat),
+    new THREE.Mesh(postGeom, postMat),
+    new THREE.Mesh(postGeom, postMat),
+    new THREE.Mesh(postGeom, postMat)
+];
+posts[0].position.set(-rackWidth/2,-0.5,rackDepth/2);
+posts[1].position.set(rackWidth/2,-0.5,rackDepth/2);
+posts[2].position.set(-rackWidth/2,-0.5,-rackDepth/2);
+posts[3].position.set(rackWidth/2,-0.5,-rackDepth/2);
+posts.forEach(p=>scene.add(p));
+
+const floorGeom = new THREE.PlaneGeometry(50,50);
+const floorMat = new THREE.MeshBasicMaterial({color:0xcccccc});
+const floor = new THREE.Mesh(floorGeom, floorMat);
+floor.rotation.x = -Math.PI/2;
+scene.add(floor);
+
+const devices = new Array(42).fill(null); // track occupancy by unit
+
+function colorFor(type){
+    return {server:0xaaaaaa, router:0x5555ff, patch:0x55aa55, blank:0x000000}[type] || 0xffffff;
+}
+
+function addDevice(type,label,start,height){
+    start = parseInt(start); height = parseInt(height);
+    if(start<1 || start+height-1>42) return;
+    for(let i=start-1;i<start-1+height;i++) if(devices[i]) return; // occupied
+    const geom = new THREE.BoxGeometry(rackWidth-0.4, height, rackDepth-0.4);
+    const mat = new THREE.MeshLambertMaterial({color:colorFor(type)});
+    const mesh = new THREE.Mesh(geom, mat);
+    mesh.position.set(0,start-0.5+height/2,-0.1);
+    scene.add(mesh);
+    const div = document.createElement('div');
+    div.textContent = label || type;
+    div.style.background='rgba(255,255,255,0.7)';
+    div.style.padding='2px 4px';
+    const labelObj = new CSS2DObject(div);
+    labelObj.position.set(0,start-0.5+height/2,rackDepth/2);
+    scene.add(labelObj);
+    for(let i=start-1;i<start-1+height;i++) devices[i]=mesh;
+}
+
+document.getElementById('add').onclick=()=>{
+    const type=document.getElementById('type').value;
+    const label=document.getElementById('label').value;
+    const start=document.getElementById('start').value;
+    const height=document.getElementById('height').value;
+    addDevice(type,label,start,height);
+};
+
+const light=new THREE.DirectionalLight(0xffffff,1);
+light.position.set(10,20,10);
+scene.add(light);
+const amb=new THREE.AmbientLight(0x404040);
+scene.add(amb);
+
+window.addEventListener('resize',()=>{
+    camera.aspect=window.innerWidth/window.innerHeight;
+    camera.updateProjectionMatrix();
+    renderer.setSize(window.innerWidth,window.innerHeight);
+    labelRenderer.setSize(window.innerWidth,window.innerHeight);
+});
+
+function animate(){
+    requestAnimationFrame(animate);
+    renderer.render(scene,camera);
+    labelRenderer.render(scene,camera);
+}
+animate();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a Three.js demo (`index.html`) to place devices in a rack
- document how to use it in the updated README

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683f60ea5bbc832ca253f28c80d9f50c