### PR TITLE
Fix drag-and-drop by ignoring label renderer pointer events

### DIFF
--- a/main.js
+++ b/main.js
@@ -15,9 +15,10 @@ const labelRenderer = new CSS2DRenderer();
 labelRenderer.setSize(window.innerWidth, window.innerHeight);
 labelRenderer.domElement.style.position = 'absolute';
 labelRenderer.domElement.style.top = '0px';
+labelRenderer.domElement.style.pointerEvents = 'none';
 document.body.appendChild(labelRenderer.domElement);
 
-const controls = new OrbitControls(camera, labelRenderer.domElement);
+const controls = new OrbitControls(camera, renderer.domElement);
 controls.maxPolarAngle = Math.PI / 2;
 controls.minPolarAngle = 0;
 


### PR DESCRIPTION
## Summary
- allow drag-and-drop interaction to reach the canvas
- hook OrbitControls to the canvas element

## Testing
- `npm install`
- `npm test`
- `pytest`
- `npm run browser-test`


------
https://chatgpt.com/codex/tasks/task_e_683f7b2161c4832c861dd11d4c7c00fe