### PR TITLE
Enhance visuals with intro animation and grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,28 @@
 
     <style>
         body { margin:0; overflow:hidden; font-family:sans-serif; }
+        #intro-container {
+            position:fixed;
+            top:0;
+            left:0;
+            width:100%;
+            height:100%;
+            background:#f0f0f0;
+            display:flex;
+            justify-content:center;
+            align-items:center;
+            z-index:200;
+        }
+        #intro-title { font-size:60px; opacity:0; }
         #overlay {
-            position:absolute;top:10px;left:10px;z-index:100;background:rgba(255,255,255,0.8);padding:10px;border-radius:4px;
+            position:absolute;
+            top:10px;
+            left:10px;
+            z-index:100;
+            background:rgba(255,255,255,0.8);
+            padding:10px;
+            border-radius:4px;
+            display:none;
         }
         .palette-item {
             padding:4px;border:1px solid #333;background:#eee;margin-bottom:5px;cursor:grab;
@@ -20,6 +40,7 @@
     </style>
 </head>
 <body>
+<div id="intro-container"><div id="intro-title">Rack Builder</div></div>
 <div id="overlay">
     <div class="palette-item" draggable="true" data-type="server">Server</div>
     <div class="palette-item" draggable="true" data-type="router">Router</div>
@@ -30,6 +51,24 @@
     <label>Name: <input id="prop-name" type="text"/></label>
     <button id="prop-save">Save</button>
 </div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js"></script>
+<script>
+    gsap.to('#intro-title', {
+        duration: 1,
+        opacity: 1,
+        scale: 1.2,
+        ease: 'back.out(1.7)'
+    });
+    gsap.to('#intro-title', {
+        delay: 1.2,
+        duration: 0.6,
+        opacity: 0,
+        onComplete: () => {
+            document.getElementById('intro-container').style.display = 'none';
+            document.getElementById('overlay').style.display = 'block';
+        }
+    });
+</script>
     <script type="importmap">
     {
         "imports": {

--- a/main.js
+++ b/main.js
@@ -5,7 +5,7 @@ import { CSS2DRenderer, CSS2DObject } from 'three/examples/jsm/renderers/CSS2DRe
 console.log('Starting App');
 
 const scene = new THREE.Scene();
-scene.background = new THREE.Color(0xeeeeee);
+scene.background = new THREE.Color(0xd8d8d8);
 const camera = new THREE.PerspectiveCamera(45, window.innerWidth/window.innerHeight, 0.1, 1000);
 const renderer = new THREE.WebGLRenderer({antialias:true});
 renderer.setSize(window.innerWidth, window.innerHeight);
@@ -59,6 +59,9 @@ const floorMat = new THREE.MeshBasicMaterial({color:0xcccccc});
 const floor = new THREE.Mesh(floorGeom, floorMat);
 floor.rotation.x = -Math.PI/2;
 scene.add(floor);
+const grid = new THREE.GridHelper(50, 50, 0x999999, 0xcccccc);
+grid.position.y = 0.01;
+scene.add(grid);
 
 const devices = new Array(42).fill(null); // track occupancy by unit
 const deviceMeshes = [];


### PR DESCRIPTION
## Summary
- add introductory animation with GSAP
- hide palette until intro completes
- tweak background color and add grid helper to the floor

## Testing
- `npm install`
- `npm test`
- `pytest`
- `npm run browser-test`

------
https://chatgpt.com/codex/tasks/task_e_683f7d48dd7c832cbe1eee3bd2900a5d