### PR TITLE
Enhance visuals with tiled floor and animated intro

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,20 +6,64 @@
     <title>3D Rack Builder v0.01</title>
 
     <style>
-        body { margin:0; overflow:hidden; font-family:sans-serif; }
+        body {
+            margin: 0;
+            overflow: hidden;
+            font-family: sans-serif;
+        }
+        #intro-container {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: #f0f0f0;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            z-index: 200;
+        }
+        #intro-title {
+            font-size: 60px;
+            opacity: 0;
+        }
         #overlay {
-            position:absolute;top:10px;left:10px;z-index:100;background:rgba(255,255,255,0.8);padding:10px;border-radius:4px;
+            position: absolute;
+            top: 10px;
+            left: 10px;
+            z-index: 100;
+            background: rgba(255, 255, 255, 0.8);
+            padding: 10px;
+            border-radius: 4px;
+            display: none;
         }
         .palette-item {
-            padding:4px;border:1px solid #333;background:#eee;margin-bottom:5px;cursor:grab;
+            padding: 4px;
+            border: 1px solid #333;
+            background: #eee;
+            margin-bottom: 5px;
+            cursor: grab;
         }
         #props {
-            position:absolute;top:10px;right:10px;z-index:100;background:rgba(255,255,255,0.9);padding:10px;border-radius:4px;display:none;
+            position: absolute;
+            top: 10px;
+            right: 10px;
+            z-index: 100;
+            background: rgba(255, 255, 255, 0.9);
+            padding: 10px;
+            border-radius: 4px;
+            display: none;
         }
-        label,input,select {display:block;margin-bottom:5px;}
+        label,
+        input,
+        select {
+            display: block;
+            margin-bottom: 5px;
+        }
     </style>
 </head>
 <body>
+<div id="intro-container"><div id="intro-title">Rack Builder</div></div>
 <div id="overlay">
     <div class="palette-item" draggable="true" data-type="server">Server</div>
     <div class="palette-item" draggable="true" data-type="router">Router</div>
@@ -30,6 +74,35 @@
     <label>Name: <input id="prop-name" type="text"/></label>
     <button id="prop-save">Save</button>
 </div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js"></script>
+<script>
+    const introTl = gsap.timeline();
+    introTl.from('#intro-title', {
+        duration: 0.8,
+        opacity: 0,
+        scale: 0.5,
+        rotation: -45,
+        ease: 'power2.out'
+    })
+    .to('#intro-title', {
+        duration: 0.8,
+        scale: 1.2,
+        rotation: 0,
+        ease: 'elastic.out(1, 0.4)'
+    })
+    .to('#intro-title', {
+        duration: 0.5,
+        opacity: 0,
+        y: -40,
+        delay: 0.3
+    })
+    .add(() => {
+        document.getElementById('intro-container').style.display = 'none';
+        const overlay = document.getElementById('overlay');
+        overlay.style.display = 'block';
+        gsap.from(overlay, { duration: 0.6, opacity: 0, x: -20 });
+    });
+</script>
     <script type="importmap">
     {
         "imports": {

--- a/main.js
+++ b/main.js
@@ -5,7 +5,7 @@ import { CSS2DRenderer, CSS2DObject } from 'three/examples/jsm/renderers/CSS2DRe
 console.log('Starting App');
 
 const scene = new THREE.Scene();
-scene.background = new THREE.Color(0xeeeeee);
+scene.background = new THREE.Color(0xd8d8d8);
 const camera = new THREE.PerspectiveCamera(45, window.innerWidth/window.innerHeight, 0.1, 1000);
 const renderer = new THREE.WebGLRenderer({antialias:true});
 renderer.setSize(window.innerWidth, window.innerHeight);
@@ -54,11 +54,36 @@ for(let i=1;i<=rackHeight;i++){
     scene.add(lbl);
 }
 
-const floorGeom = new THREE.PlaneGeometry(50,50);
-const floorMat = new THREE.MeshBasicMaterial({color:0xcccccc});
+function createTileTexture() {
+    const size = 64;
+    const canvas = document.createElement('canvas');
+    canvas.width = size;
+    canvas.height = size;
+    const ctx = canvas.getContext('2d');
+    ctx.fillStyle = '#e8e8e8';
+    ctx.fillRect(0, 0, size, size);
+    ctx.strokeStyle = '#b0b0b0';
+    ctx.lineWidth = 2;
+    ctx.strokeRect(0, 0, size, size);
+    const tex = new THREE.CanvasTexture(canvas);
+    tex.wrapS = THREE.RepeatWrapping;
+    tex.wrapT = THREE.RepeatWrapping;
+    tex.repeat.set(25, 25);
+    return tex;
+}
+
+const floorGeom = new THREE.PlaneGeometry(50, 50);
+const floorMat = new THREE.MeshStandardMaterial({
+    map: createTileTexture(),
+    metalness: 0.1,
+    roughness: 0.8
+});
 const floor = new THREE.Mesh(floorGeom, floorMat);
-floor.rotation.x = -Math.PI/2;
+floor.rotation.x = -Math.PI / 2;
 scene.add(floor);
+const grid = new THREE.GridHelper(50, 50, 0x999999, 0xcccccc);
+grid.position.y = 0.01;
+scene.add(grid);
 
 const devices = new Array(42).fill(null); // track occupancy by unit
 const deviceMeshes = [];
@@ -105,11 +130,11 @@ function addDevice(type,label,start,height,animate){
 }
 
 
-const light=new THREE.DirectionalLight(0xffffff,1);
-light.position.set(10,20,10);
-scene.add(light);
-const amb=new THREE.AmbientLight(0x404040);
-scene.add(amb);
+const dirLight = new THREE.DirectionalLight(0xffffff, 0.7);
+dirLight.position.set(10, 20, 10);
+scene.add(dirLight);
+const hemiLight = new THREE.HemisphereLight(0xffffff, 0x888888, 0.6);
+scene.add(hemiLight);
 
 document.querySelectorAll('.palette-item').forEach(el=>{
     el.addEventListener('dragstart',e=>{


### PR DESCRIPTION
## Summary
- refine GSAP intro animation and show palette after it completes
- create a tiled floor texture and use a standard material
- add hemisphere lighting for better appearance

## Testing
- `npm install`
- `npm test`
- `pytest`
- `npm run browser-test`


------
https://chatgpt.com/codex/tasks/task_e_683f7d48dd7c832cbe1eee3bd2900a5d